### PR TITLE
Lightning Grace Period Timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
     "./Drivers/Embedded-Base/threadX/src/u_tx_mutex.c"
     "./Drivers/Embedded-Base/threadX/src/u_tx_queues.c"
     "./Drivers/Embedded-Base/threadX/src/u_tx_threads.c"
+    "./Drivers/Embedded-Base/threadX/src/u_tx_timers.c"
     "./Drivers/Embedded-Base/middleware/src/bitstream.c"
     "./Drivers/Embedded-Base/middleware/src/c_utils.c"
 

--- a/Core/Inc/u_statemachine.h
+++ b/Core/Inc/u_statemachine.h
@@ -21,6 +21,7 @@ Lightning_Board_Light_Status statemachine_getState();
 
 void statemachine_handleIMDMessage(can_msg_t* message); // Handles the IMD status message. 
 void statemachine_handleBMSMessage(can_msg_t* message); // Handles the BMS status message.
+int statemachine_init(void); // Start the lightning timeout timer.
  
 #endif /* u_statemachine.h */
 

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -25,6 +25,7 @@
 /* USER CODE BEGIN Includes */
 #include "u_queues.h"
 #include "u_threads.h"
+#include "u_statemachine.h"
 #include "u_mutexes.h"
 #include "u_sensors.h"
 /* USER CODE END Includes */
@@ -72,6 +73,7 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
   CATCH_ERROR(init_lightning_sensor(), U_SUCCESS);
   // CATCH_ERROR(init_magnetometer(), U_SUCCESS);
   CATCH_ERROR(threads_init(byte_pool), U_SUCCESS);
+  CATCH_ERROR(statemachine_init(), U_SUCCESS);
 
   /* USER CODE END App_ThreadX_MEM_POOL */
   /* USER CODE BEGIN App_ThreadX_Init */

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -8,7 +8,7 @@
 #include "u_mutexes.h"
 
 /* Lightning Timeout */
-#define LIGHTNING_TIMEOUT_DURATION 5 // Duration of lightning's post-boot grace period, in ticks.
+#define LIGHTNING_TIMEOUT_DURATION 5000 // Duration of lightning's post-boot grace period, in ticks.
 static _Atomic bool grace_period = true; // If `true`, lightning is still within its post-boot grace period and will force LIGHT_OFF no matter what.
 static void _lightning_timeout_callback(ULONG args) { grace_period = false; } // Callback to be called after the timer expires.
 static timer_t lightning_timeout = {
@@ -105,6 +105,7 @@ void statemachine_handleBMSMessage(can_msg_t* message) {
 }
 
 Lightning_Board_Light_Status statemachine_getState() {
+    PRINTLN_INFO("grace_period = %d", grace_period);
     /* If we haven't made first contact yet from either board, or we are still in our grace period, just return LIGHT_OFF. */
     if(!has_bms_made_contact || !has_imd_made_contact || grace_period) {
         return LIGHT_OFF;

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -4,7 +4,24 @@
 #include "u_can.h"
 #include "can_messages_rx.h"
 #include "u_statemachine.h"
+#include "u_tx_timers.h"
 #include "u_mutexes.h"
+
+/* Lightning Timeout */
+#define LIGHTNING_TIMEOUT_DURATION 5 // Duration of lightning's post-boot grace period, in ticks.
+static _Atomic bool grace_period = true; // If `true`, lightning is still within its post-boot grace period and will force LIGHT_OFF no matter what.
+static void _lightning_timeout_callback(ULONG args) { grace_period = false; } // Callback to be called after the timer expires.
+static timer_t lightning_timeout = {
+    .name = "Lightning Timeout Timer",
+    .callback = _lightning_timeout_callback,
+    .duration = LIGHTNING_TIMEOUT_DURATION,
+    .type = ONESHOT,
+    .auto_activate = true
+};
+// This timer implements Lightning's post-boot grace period.
+// For the first few seconds after starting up, we don't want to set an official light state, as IMD and BMS are still getting started.
+// So, during this grace period, we will always set LIGHT_OFF.
+// Once the grace period is up, we will actually start using the BMS and IMD states to choose LIGHT_RED or LIGHT_GREEN.
 
 /* First contact trackers. */
 static _Atomic bool has_bms_made_contact = false;
@@ -69,8 +86,8 @@ void statemachine_handleBMSMessage(can_msg_t* message) {
 }
 
 Lightning_Board_Light_Status statemachine_getState() {
-    /* If we haven't made first contact yet from either board, just return LIGHT_OFF. */
-    if(!has_bms_made_contact || !has_imd_made_contact) {
+    /* If we haven't made first contact yet from either board, or we are still in our grace period, just return LIGHT_OFF. */
+    if(!has_bms_made_contact || !has_imd_made_contact || grace_period) {
         return LIGHT_OFF;
     }
     

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -16,7 +16,7 @@ static timer_t lightning_timeout = {
     .callback = _lightning_timeout_callback,
     .duration = LIGHTNING_TIMEOUT_DURATION,
     .type = ONESHOT,
-    .auto_activate = true
+    .auto_activate = false
 };
 // This timer implements Lightning's post-boot grace period.
 // For the first few seconds after starting up, we don't want to set an official light state, as IMD and BMS are still getting started.
@@ -36,6 +36,25 @@ static _Atomic bool bms_error; // Is the BMS okay? false = bms is okay, true = b
 static _Atomic bool imd_error; // Is the IMD okay? false = imd is okay, true = imd is NOT okay.
 // These values are updated via CAN messages that are sent from the BMS and IMD.
 // As explained in the "first contact trackers" section, these bools are not used by the statemachine until at least one "okay" message has been received from each board.
+
+/* Initialize the lightning timeout timer. */
+int statemachine_init(void) {
+    /* Initialize the lightning timeout timer. */
+    int status = timer_init(&lightning_timeout);
+    if(status != U_SUCCESS) {
+        PRINTLN_ERROR("Failed to call timer_init() (Timer: %s, Status: %d).", lightning_timeout.name, status);
+        return U_ERROR;
+    }
+
+    /* Start the lightning timeout timer. */
+    status = timer_start(&lightning_timeout);
+    if(status != U_SUCCESS) {
+        PRINTLN_ERROR("Failed to call timer_start() (Timer: %s, Status: %d).", lightning_timeout.name, status);
+        return U_ERROR;
+    }
+
+    return U_SUCCESS;
+}
 
 /* Handles the IMD status message. */
 #define _GET_BIT(data, bit) (((data) & (1U << (bit))) != 0U)


### PR DESCRIPTION
Lightning now has a 5 second post-boot grace period, where it forces `LIGHT_OFF` regardless of what the IMD and BMS statuses say.